### PR TITLE
Use hash structures when it makes sense

### DIFF
--- a/src/event/event_hash.rs
+++ b/src/event/event_hash.rs
@@ -1,5 +1,6 @@
 use ring::digest::Digest;
 use serde::ser::{Serialize, Serializer};
+use std::hash::{Hash, Hasher};
 use std::cmp::Ordering;
 
 #[derive(Clone, Copy)]
@@ -8,6 +9,12 @@ pub struct EventHash(pub Digest);
 impl Serialize for EventHash {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         self.0.as_ref().serialize(serializer)
+    }
+}
+
+impl Hash for EventHash {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
     }
 }
 


### PR DESCRIPTION
`Hashgraph` needs to use `BTreeMap` because the order it's
important to make the serialization deterministic. So I created
the appropriate traits for `EventHash` to handle that and used
b-tree like structures every time I needed a map or a set with
`EventHash`.

However, that's not always the most efficient choice. In this
commit, I implemented the `Hash` trait for `EventHash` and used
hash based structures in the places where order isn't
important.

Fixes #7.