### PR TITLE
Make Node capable of sharing its current status

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,14 @@
+use failure::Backtrace;
+use std::sync::PoisonError;
+
 #[derive(Debug, Fail)]
 pub(crate) enum NodeError {
     #[fail(display = "The node network it's empty")]
     EmptyNetwork,
     #[fail(display = "The node has no head")]
     NoHead,
+    #[fail(display = "Peer not found")]
+    PeerNotFound,
 }
 
 #[derive(Debug, Fail)]
@@ -26,4 +31,67 @@ pub(crate) enum EventError {
 pub(crate) enum HashgraphError {
     #[fail(display = "Event not found in hashgraph")]
     EventNotFound,
+}
+
+#[derive(Debug, Fail)]
+#[fail(display = "Hashgraph Mutex was poisoned")]
+pub struct ResourceHashgraphPoisonError {
+    backtrace: Backtrace
+}
+
+impl ResourceHashgraphPoisonError {
+    pub fn new() -> ResourceHashgraphPoisonError {
+        ResourceHashgraphPoisonError {
+            backtrace: Backtrace::new()
+        }
+    }
+}
+
+//for op-?, "auto" type conversion
+impl<T> From<PoisonError<T>> for ResourceHashgraphPoisonError {
+    fn from(_: PoisonError<T>) -> Self {
+        ResourceHashgraphPoisonError::new()
+    }
+}
+
+#[derive(Debug, Fail)]
+#[fail(display = "Head Mutex was poisoned")]
+pub struct ResourceHeadPoisonError {
+    backtrace: Backtrace
+}
+
+impl ResourceHeadPoisonError {
+    pub fn new() -> ResourceHeadPoisonError {
+        ResourceHeadPoisonError {
+            backtrace: Backtrace::new()
+        }
+    }
+}
+
+//for op-?, "auto" type conversion
+impl<T> From<PoisonError<T>> for ResourceHeadPoisonError {
+    fn from(_: PoisonError<T>) -> Self {
+        ResourceHeadPoisonError::new()
+    }
+}
+
+#[derive(Debug, Fail)]
+#[fail(display = "Network Mutex was poisoned")]
+pub struct ResourceNetworkPoisonError {
+    backtrace: Backtrace
+}
+
+impl ResourceNetworkPoisonError {
+    pub fn new() -> ResourceNetworkPoisonError {
+        ResourceNetworkPoisonError {
+            backtrace: Backtrace::new()
+        }
+    }
+}
+
+//for op-?, "auto" type conversion
+impl<T> From<PoisonError<T>> for ResourceNetworkPoisonError {
+    fn from(_: PoisonError<T>) -> Self {
+        ResourceNetworkPoisonError::new()
+    }
 }

--- a/src/hashgraph.rs
+++ b/src/hashgraph.rs
@@ -5,6 +5,7 @@ use peer::PeerId;
 use std::collections::{BTreeMap, HashMap};
 use std::iter::repeat_with;
 
+#[derive(Clone)]
 pub struct Hashgraph(BTreeMap<EventHash, Event>);
 
 impl Hashgraph {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -5,5 +5,6 @@ pub type PeerId = Vec<u8>;
 
 pub trait Peer {
     fn get_sync(&self, pk: PeerId) -> (EventHash, Hashgraph);
+    fn send_sync(&self, msg: (EventHash, Hashgraph));
     fn id(&self) -> &PeerId;
 }


### PR DESCRIPTION
`Node` has now a functionality to start listening for messages
from other nodes in the network asking from its current status.

In order to this, it was necessary to make `Node` thread safe.

There're three structures that can be modified by more than one
thread at the same time right now:

- The head.
- The hashgraph.
- The network.

This PR wraps them into `Mutex` to make sure that they're safe
to share. Now one can safely wrap `Node` in `Arc` and share it
between threads.

Closes #5