### PR TITLE
Refactor Hashgraph and node to use traits

### DIFF
--- a/lachesis-rs/src/event/event.rs
+++ b/lachesis-rs/src/event/event.rs
@@ -5,16 +5,18 @@ use failure::Error;
 use hashgraph::Hashgraph;
 use peer::PeerId;
 use ring::digest::{digest, SHA256};
+use std::cell::RefCell;
 use std::cmp::max;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 #[derive(Clone, Eq, PartialEq, Serialize)]
 pub struct Parents(pub EventHash, pub EventHash);
 
 impl Parents {
-    pub fn max_round(&self, hg: &Hashgraph) -> Result<usize, Error> {
-        let other_round = hg.get(&self.1)?.round()?;
-        let self_round = hg.get(&self.0)?.round()?;
+    pub fn max_round(&self, hg: Rc<RefCell<Hashgraph>>) -> Result<usize, Error> {
+        let other_round = hg.borrow().get(&self.1)?.round()?;
+        let self_round = hg.borrow().get(&self.0)?.round()?;
         Ok(max(other_round, self_round))
     }
 }

--- a/lachesis-rs/src/peer.rs
+++ b/lachesis-rs/src/peer.rs
@@ -1,10 +1,12 @@
 use event::EventHash;
 use hashgraph::Hashgraph;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub type PeerId = Vec<u8>;
 
 pub trait Peer {
-    fn get_sync(&self, pk: PeerId) -> (EventHash, Hashgraph);
-    fn send_sync(&self, msg: (EventHash, Hashgraph));
+    fn get_sync(&self, pk: PeerId) -> (EventHash, Rc<RefCell<Hashgraph>>);
+    fn send_sync(&self, msg: (EventHash, Rc<RefCell<Hashgraph>>));
     fn id(&self) -> &PeerId;
 }


### PR DESCRIPTION
Let's make node accept "a hashgraph" instead of "the
hashgraph".

To do so, we changed the struct `Hashgraph` to be instead a
`BTreeHashgraph` structure implementing the `Hashgraph` trait
and then make `Node` get a `Rc<RefCell<Hashgraph>>` instead of
just `Hashgraph`.