### PR TITLE
Create tests for node

### DIFF
--- a/lachesis-rs/src/event/event.rs
+++ b/lachesis-rs/src/event/event.rs
@@ -10,7 +10,7 @@ use std::cmp::max;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-#[derive(Clone, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Parents(pub EventHash, pub EventHash);
 
 impl Parents {
@@ -21,7 +21,7 @@ impl Parents {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Event {
     #[serde(skip)]
     can_see: HashMap<PeerId, EventHash>,
@@ -122,7 +122,7 @@ impl Event {
 
     #[inline]
     pub fn is_root(&self) -> bool {
-        self.parents.is_some()
+        self.parents.is_none()
     }
 
     #[inline]

--- a/lachesis-rs/src/event/event_signature.rs
+++ b/lachesis-rs/src/event/event_signature.rs
@@ -3,6 +3,7 @@ use failure::Error;
 use peer::PeerId;
 use ring::signature::{ED25519, Signature, verify};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
+use std::fmt;
 
 #[derive(Clone)]
 pub struct EventSignature(pub Signature);
@@ -30,3 +31,16 @@ impl AsRef<[u8]> for EventSignature {
         self.0.as_ref()
     }
 }
+
+impl fmt::Debug for EventSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0.as_ref())
+    }
+}
+
+impl PartialEq for EventSignature {
+    fn eq(&self, other: &EventSignature) -> bool {
+        self.0.as_ref() == other.0.as_ref()
+    }
+}
+impl Eq for EventSignature {}

--- a/lachesis-rs/src/hashgraph.rs
+++ b/lachesis-rs/src/hashgraph.rs
@@ -11,7 +11,6 @@ pub trait Hashgraph {
     fn get_mut(&mut self, id: &EventHash) -> Result<&mut Event, Error>;
     fn get(&self, id: &EventHash) -> Result<&Event, Error>;
     fn insert(&mut self, hash: EventHash, event: Event);
-    fn extract(&mut self, id: &EventHash) -> Result<Event, Error>;
     fn ancestors<'a>(&'a self, id: &'a EventHash) -> Vec<&'a EventHash>;
     fn other_ancestors<'a>(&'a self, id: &'a EventHash) -> Vec<&'a EventHash>;
     fn self_ancestors<'a>(&'a self, id: &'a EventHash) -> Vec<&'a EventHash>;
@@ -43,10 +42,6 @@ impl Hashgraph for BTreeHashgraph {
 
     fn insert(&mut self, hash: EventHash, event: Event) {
         self.0.insert(hash, event);
-    }
-
-    fn extract(&mut self, id: &EventHash) -> Result<Event, Error> {
-        self.0.remove(id).ok_or(Error::from(HashgraphError::EventNotFound))
     }
 
     fn ancestors<'a>(&'a self, id: &'a EventHash) -> Vec<&'a EventHash> {

--- a/lachesis-rs/src/lib.rs
+++ b/lachesis-rs/src/lib.rs
@@ -14,6 +14,7 @@ mod node;
 mod peer;
 mod round;
 
+pub use hashgraph::{BTreeHashgraph, Hashgraph};
 pub use event::Event;
 pub use node::Node;
 pub use peer::Peer;


### PR DESCRIPTION
They are not really unitary, since they depend on one implementation of
`Hashgraph`. In an ideal world, one of the mocking libraries of rust
would work correctly in our project, but after spending way too much
time trying to make them happy I got nothing but sadness and was forced
down this road.

We could also create a custom, test only `Hashgraph` implementation
therefore making this unit test again. But the line it's so blurry right
now that it doesn't really matter. I'm willing to open a ticket
tracking this problem, though.

Closes #14 