### PR TITLE
Create an implementation of Peer using TCP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "dummy",
     "lachesis-rs",
     "fal",
+    "tcp-client",
 ]

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(never_type)]
 
-extern crate bincode;
 extern crate env_logger;
 extern crate lachesis_rs;
 #[macro_use] extern crate log;

--- a/lachesis-rs/src/errors.rs
+++ b/lachesis-rs/src/errors.rs
@@ -1,4 +1,5 @@
 use event::EventHash;
+use peer::PeerId;
 use printable_hash::PrintableHash;
 use failure::Backtrace;
 use std::fmt;
@@ -6,6 +7,7 @@ use std::sync::PoisonError;
 
 #[derive(Debug)]
 pub(crate) enum NodeErrorType {
+    PeerNotFound(PeerId),
     EmptyNetwork,
     NoHead,
 }
@@ -13,8 +15,9 @@ pub(crate) enum NodeErrorType {
 impl fmt::Display for NodeErrorType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let msg = match self {
-            NodeErrorType::EmptyNetwork => "The node network it's empty",
-            NodeErrorType::NoHead => "The node has no head",
+            NodeErrorType::EmptyNetwork => String::from("The node network it's empty"),
+            NodeErrorType::NoHead => String::from("The node has no head"),
+            NodeErrorType::PeerNotFound(p) => format!("Peer {} not found", p.printable_hash()),
         };
         write!(f, "{}", msg)
     }

--- a/lachesis-rs/src/node.rs
+++ b/lachesis-rs/src/node.rs
@@ -361,6 +361,15 @@ impl<P: Peer<H>, H: Hashgraph + Clone + fmt::Debug> Node<P, H> {
             .ok_or(Error::from(NodeError::new(NodeErrorType::NoHead)))
     }
 
+    pub fn get_peer(&self, id: &PeerId) -> Result<Arc<Box<P>>, Error> {
+        let state = get_from_mutex!(self.state, ResourceNodeInternalStatePoisonError)?;
+        state
+            .network
+            .get(id)
+            .map(|v| v.clone())
+            .ok_or(Error::from(NodeError::new(NodeErrorType::PeerNotFound(id.clone()))))
+    }
+
     #[inline]
     fn update_famous_events(&self, famous_events: HashMap<EventHash, bool>) -> Result<(), Error> {
         let mut hashgraph = get_from_mutex!(self.hashgraph, ResourceHashgraphPoisonError)?;

--- a/tcp-client/Cargo.toml
+++ b/tcp-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "dummy"
+name = "tcp-client"
 version = "0.1.0"
 authors = ["Agustin Chiappe Berrini <jnieve@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+bincode = "1.0.1"
 env_logger = "0.6.0"
 lachesis-rs = { path = "../lachesis-rs" }
 log = "0.4"
 rand = "0.6.0"
 ring = "0.13.4"
 untrusted = "0.6.2"
-

--- a/tcp-client/src/lib.rs
+++ b/tcp-client/src/lib.rs
@@ -1,0 +1,102 @@
+#[macro_use] extern crate log;
+use bincode::serialize;
+use lachesis_rs::{BTreeHashgraph, EventHash, HashgraphWire, Node, Peer, PeerId};
+use ring::rand::SystemRandom;
+use ring::signature;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::thread::{JoinHandle, sleep, spawn};
+use std::time::Duration;
+
+fn create_node(rng: &mut SystemRandom) -> Node<TcpNode, BTreeHashgraph> {
+    let hashgraph = BTreeHashgraph::new();
+    let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8(rng).unwrap();
+    let kp = signature::Ed25519KeyPair::from_pkcs8(untrusted::Input::from(&pkcs8_bytes)).unwrap();
+    Node::new(kp, hashgraph).unwrap()
+}
+
+pub struct TcpNode {
+    id: PeerId,
+    pub access_address: String,
+    pub node: Node<TcpNode, BTreeHashgraph>,
+}
+
+impl TcpNode {
+    pub fn new(rng: &mut SystemRandom, access_address: String) -> TcpNode {
+        let node = create_node(rng);
+        let id = node.get_id();
+        TcpNode {
+            access_address,
+            id,
+            node,
+        }
+    }
+}
+
+impl Peer<BTreeHashgraph> for TcpNode {
+    fn get_sync(&self, pk: PeerId) -> (EventHash, BTreeHashgraph) {
+        let peer = self.node.get_peer(&pk).unwrap();
+        let mut buffer = Vec::new();
+        let mut stream = TcpStream::connect(&peer.access_address).unwrap();
+        let mut last_received = 0;
+        while last_received == 0 {
+            last_received = stream.read_to_end(&mut buffer).unwrap();
+        }
+        let (eh, wire): (EventHash, HashgraphWire) = bincode::deserialize(&buffer).unwrap();
+        let hashgraph = BTreeHashgraph::from(wire);
+        (eh, hashgraph)
+    }
+    fn id(&self) -> &PeerId {
+        &self.id
+    }
+}
+
+pub struct TcpApp(pub Arc<Box<TcpNode>>);
+
+impl TcpApp {
+    pub fn new(n: Arc<Box<TcpNode>>) -> TcpApp {
+        TcpApp(n)
+    }
+
+    pub fn run(self) -> (JoinHandle<()>, JoinHandle<()>) {
+        let answer_thread_node = self.0.clone();
+        let sync_thread_node = self.0.clone();
+        let answer_handle = spawn(move || {
+            let listener = TcpListener::bind(&answer_thread_node.access_address).unwrap();
+            for stream_result in listener.incoming() {
+                let mut stream = stream_result.unwrap();
+                let message = answer_thread_node.node.respond_message().unwrap();
+                let payload = serialize(&message).unwrap();
+                stream.write(&payload).unwrap();
+            }
+            ()
+        });
+        let sync_handle = spawn(move || {
+            let mut rng = rand::thread_rng();
+            let mut counter = 0usize;
+            let node_id = sync_thread_node.node.get_id();
+            loop {
+                if counter % 100 == 0 {
+                    let head = sync_thread_node.node.get_head().unwrap();
+                    let (n_rounds, n_events) = sync_thread_node.node.get_stats().unwrap();
+                    info!(
+                        "Node {:?}: Head {:?} Rounds {:?} Pending events {:?}",
+                        node_id,
+                        head,
+                        n_rounds,
+                        n_events
+                    );
+                }
+                match sync_thread_node.node.run(&mut rng) {
+                    Ok(_) => {},
+                    Err(e) => panic!("Error! {}", e),
+                };
+                counter += 1;
+                sleep(Duration::from_millis(100));
+            }
+            ()
+        });
+        (answer_handle, sync_handle)
+    }
+}

--- a/tcp-client/src/main.rs
+++ b/tcp-client/src/main.rs
@@ -1,0 +1,38 @@
+use tcp_client::*;
+use std::env::args;
+use std::sync::Arc;
+
+const BASE_PORT: usize = 9000;
+const USAGE: &'static str = "Usage: tcp-client [number of nodes]";
+
+fn main() {
+    env_logger::init();
+    let args: Vec<String> = args().collect();
+    if args.len() != 2 {
+        panic!(USAGE);
+    }
+    let mut rng = ring::rand::SystemRandom::new();
+    let n_nodes = args[1].parse::<usize>().unwrap();
+    let mut nodes = Vec::with_capacity(n_nodes);
+    for i in 0..n_nodes {
+        let a = format!("0.0.0.0:{}", BASE_PORT + i);
+        nodes.push(Arc::new(Box::new(TcpNode::new(&mut rng, a))));
+    }
+    for node in nodes.iter() {
+        for peer in nodes.iter() {
+            if peer.node.get_id() != node.node.get_id() {
+                node.node.add_node(peer.clone()).unwrap();
+            }
+        }
+    }
+    let mut handles = Vec::with_capacity(n_nodes * 2);
+    for node in nodes.iter() {
+        let app = TcpApp(node.clone());
+        let (handle1, handle2) = app.run();
+        handles.push(handle1);
+        handles.push(handle2);
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}


### PR DESCRIPTION
There's a lot of duplicated code from Dummy. There's a
non-written rule in software development that says once you
repeat something more than two times, you should abstract it,
not sooner and not later. This is the second time. If the next
implementations turns out to need the same infrastructure, it's
time to abstract the common parts. For now, let's leave it as
is, as it might be coincidental and I don't want to add
unnecessary layers of complexity.

Other than that, pretty straight forward once you understand
Dummy. The only difference is that instead of communicating
between processes now it communicates through TCP streams.

The network protocol is very simple:

- A connection open to a peer is interpreted as a request to
sync.
- On connection open, the peer sends current head and hashgraph
to the client. In bincode.
- After that, connection is closed.
- No other transmission so far.

Right now, that might be sent into multiple tcp packages,
depending on the hashgraph's size. Over time, that number will
grow. An easy way to ease this would be to make the
`HashgraphWire` include just the subset of the graph that is
still being worked on, as mentioned in the paper. But this pr
doesn't address that.

This closes #4.